### PR TITLE
Methods: fix references to OpenAI links

### DIFF
--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -74,18 +74,18 @@ Davinci models are the most powerful GPT-3 model, whereas Curie ones are less ca
 Although the edits endpoints would be the ideal interface for our task, it is still in beta.
 Therefore, we mainly focused on the completion endpoint.
 <!-- REMEMBER TO SEND RESULTS TO OPENAI ABOUT THE edits endpoint, they are requesting feedback -->
-All models can be fine-tuned using different parameters [@url:https://beta.openai.com/docs/api-reference/completions], and the most important ones can be easily adjusted using our tool.
+All models can be fine-tuned using different parameters (see [OpenAI - API Reference](https://beta.openai.com/docs/api-reference/completions)), and the most important ones can be easily adjusted using our tool.
 
 
 Language models for text completion have a context length that indicates the limit of tokens they can process (tokens are common character sequences in text).
 This limit includes the size of the prompt and the paragraph, and the maximum number of tokens to generate for the completion (parameter `max_tokens`).
-For instance, the context length of Davinci models is 4,000, and 2,048 for Curie [@url:https://beta.openai.com/docs/models/overview].
+For instance, the context length of Davinci models is 4,000, and 2,048 for Curie (see [OpenAI - Models overview](https://beta.openai.com/docs/models/overview)).
 For this reason, it is still not possible to use the entire manuscript as input, not even entire sections.
 Therefore, our AI-assisted revision software process each paragraph of the manuscript with section-specific prompts, as shown in Figure {@fig:ai_revision}b.
 The advantage of this approach is the ability to process large manuscripts by processing small chunks of text.
 The main issue, however, is that the language model processes only a single paragraph from a section, potentially losing important context to produce a better output.
 Nonetheless, we find that the model still produces high-quality output (see [Results](#sec:results)).
-Additionally, since the goal of our tool is to revise a paragraph, by default we set the maximum number of tokens (parameter `max_tokens`) as twice the estimated number of tokens in the paragraph (one token approximately represents four characters, as indicated in [@url:https://beta.openai.com/tokenizer]).
+Additionally, since the goal of our tool is to revise a paragraph, by default we set the maximum number of tokens (parameter `max_tokens`) as twice the estimated number of tokens in the paragraph (one token approximately represents four characters, see [OpenAI - Tokenizer](https://beta.openai.com/tokenizer])).
 The tool automatically adjusts this parameter and performs the request again if a related error is returned by the API.
 The user can force the tool to either use a fixed value for `max_tokens` for all paragraphs, or change the fraction of maximum tokens based on the estimated paragraph size (two by default).
 


### PR DESCRIPTION
Using the `@url` format in these cases does not work well, so I'm just adding text with links. Not sure if this is the best way to do it.