### PR TITLE
potential fix

### DIFF
--- a/ci/run-manuscript-editor.py
+++ b/ci/run-manuscript-editor.py
@@ -19,9 +19,9 @@ if __name__ == "__main__":
     )
 
     # revise the manuscript
-    with tempfile.TemporaryDirectory() as output_folder:
-        me.revise_manuscript(output_folder, model, debug=True)
+    output_folder = tempfile.TemporaryDirectory()
+    me.revise_manuscript(output_folder, model, debug=True)
 
-        # move the revised manuscript back to the content folder
-        for f in output_folder.glob("*"):
-            f.rename(me.content_dir / f.name)
+    # move the revised manuscript back to the content folder
+    for f in output_folder.glob("*"):
+        f.rename(me.content_dir / f.name)

--- a/ci/run-manuscript-editor.py
+++ b/ci/run-manuscript-editor.py
@@ -19,9 +19,12 @@ if __name__ == "__main__":
     )
 
     # revise the manuscript
-    output_folder = tempfile.TemporaryDirectory()
-    me.revise_manuscript(output_folder, model, debug=True)
+    with tempfile.TemporaryDirectory() as t:
+        output_folder = Path(t)
+        print(f"Temporary directory: {output_folder}")
 
-    # move the revised manuscript back to the content folder
-    for f in output_folder.glob("*"):
-        f.rename(me.content_dir / f.name)
+        me.revise_manuscript(output_folder, model, debug=True)
+
+        # move the revised manuscript back to the content folder
+        for f in output_folder.glob("*"):
+            f.rename(me.content_dir / f.name)

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -62,10 +62,6 @@ The section of a paragraph is automatically inferred from the file name using a 
 If the tool fails to infer a section from the file, then the file will not be processed.
 If this happens, the user is still able to specify which section the file belongs to.
 The section could be a standard one (abstract, introduction, results, methods, or discussion) for which a specific prompt is used (Figure {@fig:ai_revision}b), or a non-standard one for which a default prompt will be used to instruct the model to perform only a basic revision (`minimize the use of jargon, ensure text grammar is correct spelling errors are fixed, and the text has a clear sentence structure`).
-<!--
-TODO:
-  - make sure the documentation of the workflow mention this section mapping, and also custom sections (using the default prompt)
- -->
 
 
 ### Properties of language models
@@ -75,7 +71,6 @@ We tested our tool using Davinci and Curie models, including `text-davinci-003`,
 Davinci models are the most powerful GPT-3 model, whereas Curie ones are less capable but faster and less expensive.
 Although the edits endpoints would be the ideal interface for our task, it is still in beta.
 Therefore, we mainly focused on the completion endpoint.
-<!-- REMEMBER TO SEND RESULTS TO OPENAI ABOUT THE edits endpoint, they are requesting feedback -->
 All models can be fine-tuned using different parameters (see [OpenAI - API Reference](https://beta.openai.com/docs/api-reference/completions)), and the most important ones can be easily adjusted using our tool.
 
 


### PR DESCRIPTION
From: https://docs.python.org/3/library/tempfile.html
> The directory name can be retrieved from the name attribute of the returned object. When the returned object is used as a context manager, the name will be assigned to the target of the as clause in the with statement, if there is one.

I think this was making the TemporaryDirectory come back as a string, so glob no longer worked. The suggested changes remove the `with` syntax. It may become important to clean up the temporary directory - I'm not sure if `cleanup()` behavior changes without `with`.